### PR TITLE
Solution for lack of output

### DIFF
--- a/Sessions/MCPSession.m
+++ b/Sessions/MCPSession.m
@@ -373,7 +373,6 @@ void completion(const char *command, linenoiseCompletions *lc) {
     [self setTitle]; // Temporary, until the apps restore the right state.
     [_device setRawMode:NO];
   }
-  ios_closeSession(_stream.out);
   [self out:"Bye!"];
 
   return 0;
@@ -606,6 +605,8 @@ void completion(const char *command, linenoiseCompletions *lc) {
     fclose(_stream.in);
     _stream.in = NULL;
   }
+  // Instruct ios_system to release the data for this shell:
+  ios_closeSession((__bridge void*)self);
 }
 
 - (void)suspend

--- a/Sessions/SystemSession.m
+++ b/Sessions/SystemSession.m
@@ -28,16 +28,9 @@
   sprintf(columnCountString, "%i", _device->win.ws_col);
   setenv("COLUMNS", columnCountString, 1); // force rewrite of value
   // Redirect all output to console:
-  FILE* saved_out = stdout;
-  FILE* saved_err = stderr;
-  stdin = _stream.in;
-  stdout = _stream.out;
-  stderr = stdout;
+  ios_setStreams(_stream.in, _stream.out, _stream.out);
   int res = ios_system(args);
   // get all output back:
-  stdout = saved_out;
-  stderr = saved_err;
-  stdin = _stream.in;
   //        [self _setAutoCarriageReturn:NO];
   return res;
 }


### PR DESCRIPTION
Hi @yury, 

it seems you had an intermediate version (`switchSession` and `closeSession` had different parameters). 

This one uses the latest functions introduced in ios_system, notably `ios_setStreams(_stream.in, _stream.out, _stream.out);`, which avoids the need to backup stdout. It should work better now.